### PR TITLE
fix: install optional converter backends out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Development: https://github.com/microsoft/markitdown
 
 Python tool for converting files and office documents to Markdown.
 
+markitdown installs the optional converter backends as well; use
+markitdown-core for the mandatory dependencies only.
+
 Current build status
 ====================
 
@@ -33,6 +36,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-markitdown-green.svg)](https://anaconda.org/conda-forge/markitdown) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/markitdown.svg)](https://anaconda.org/conda-forge/markitdown) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/markitdown.svg)](https://anaconda.org/conda-forge/markitdown) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/markitdown.svg)](https://anaconda.org/conda-forge/markitdown) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-markitdown--core-green.svg)](https://anaconda.org/conda-forge/markitdown-core) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/markitdown-core.svg)](https://anaconda.org/conda-forge/markitdown-core) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/markitdown-core.svg)](https://anaconda.org/conda-forge/markitdown-core) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/markitdown-core.svg)](https://anaconda.org/conda-forge/markitdown-core) |
 
 Installing markitdown
 =====================
@@ -44,16 +48,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `markitdown` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `markitdown, markitdown-core` can be installed with `conda`:
 
 ```
-conda install markitdown
+conda install markitdown markitdown-core
 ```
 
 or with `mamba`:
 
 ```
-mamba install markitdown
+mamba install markitdown markitdown-core
 ```
 
 It is possible to list all of the versions of `markitdown` available on your platform with `conda`:

--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ Development: https://github.com/microsoft/markitdown
 
 Python tool for converting files and office documents to Markdown.
 
-markitdown installs the optional converter backends as well; use
-markitdown-core for the mandatory dependencies only.
-
 Current build status
 ====================
 
@@ -36,7 +33,6 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-markitdown-green.svg)](https://anaconda.org/conda-forge/markitdown) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/markitdown.svg)](https://anaconda.org/conda-forge/markitdown) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/markitdown.svg)](https://anaconda.org/conda-forge/markitdown) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/markitdown.svg)](https://anaconda.org/conda-forge/markitdown) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-markitdown--core-green.svg)](https://anaconda.org/conda-forge/markitdown-core) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/markitdown-core.svg)](https://anaconda.org/conda-forge/markitdown-core) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/markitdown-core.svg)](https://anaconda.org/conda-forge/markitdown-core) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/markitdown-core.svg)](https://anaconda.org/conda-forge/markitdown-core) |
 
 Installing markitdown
 =====================
@@ -48,16 +44,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `markitdown, markitdown-core` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `markitdown` can be installed with `conda`:
 
 ```
-conda install markitdown markitdown-core
+conda install markitdown
 ```
 
 or with `mamba`:
 
 ```
-mamba install markitdown markitdown-core
+mamba install markitdown
 ```
 
 It is possible to list all of the versions of `markitdown` available on your platform with `conda`:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -7,7 +7,7 @@ context:
   python_min: '3.10'
   python_max: '4.0'
 
-package:
+recipe:
   name: ${{ name|lower }}
   version: ${{ version }}
 
@@ -16,60 +16,106 @@ source:
   sha256: 4d1f3c69cd43b82288fdc3653686d759dcf355ee7c681aa6a855aed98a1e4f44
 
 build:
-  number: 0
-  noarch: python
-  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
-  python:
-    entry_points:
-      - markitdown = markitdown.__main__:main
+  number: 1
 
-requirements:
-  host:
-    - python ${{ python_min }}.*
-    - hatchling
-    - pip
-  run:
-    - python >=${{ python_min }},<${{ python_max }}
-    - beautifulsoup4
-    - requests
-    - markdownify
-    # magika 0.6.3's wheel caps onnxruntime<=1.20.1 on win32 (a one-version aberration;
-    # absent in 0.6.1/0.6.2 and 1.0+), which conda can't satisfy on Windows (onnxruntime
-    # 1.26) -> downstream pip check fails. Pin away from 0.6.3 (0.6.2 is clean).
-    - magika >=0.6.1,!=0.6.3,<0.7.0
-    - charset-normalizer
-    - defusedxml
-    # https://github.com/microsoft/markitdown/blob/main/packages/markitdown/pyproject.toml#L35
-  run_constraints:
-    - python-pptx
-    - mammoth >=1.11.0
-    - pandas
-    - openpyxl
-    - xlrd
-    - lxml
-    - pdfminer.six >=20251230
-    - pdfplumber >=0.11.9
-    - olefile
-    - pydub
-    - SpeechRecognition
-    - youtube-transcript-api >=1.0.0
-    - azure-ai-documentintelligence
-    - azure-identity
-
-tests:
-  - python:
-      imports:
-        - markitdown
-      pip_check: true
-      python_version:
-        - ${{ python_min }}.*
-        - "*"
-  - requirements:
-      run:
-        - pip
+# markitdown-core carries the package with only the mandatory dependencies, so
+# every converter that needs an optional backend raises MissingDependencyException.
+# markitdown adds those backends on top, i.e. it is the equivalent of
+# `pip install markitdown[all]` and converts pdf/docx/xlsx/... out of the box.
+# https://github.com/conda-forge/markitdown-feedstock/issues/17
+outputs:
+  - package:
+      name: ${{ name|lower }}-core
+    build:
+      noarch: python
+      script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
+      python:
+        entry_points:
+          - markitdown = markitdown.__main__:main
+    requirements:
+      host:
         - python ${{ python_min }}.*
-    script:
-      - markitdown --help
+        - hatchling
+        - pip
+      run:
+        - python >=${{ python_min }},<${{ python_max }}
+        - beautifulsoup4
+        - requests
+        - markdownify
+        # magika 0.6.3's wheel caps onnxruntime<=1.20.1 on win32 (a one-version aberration;
+        # absent in 0.6.1/0.6.2 and 1.0+), which conda can't satisfy on Windows (onnxruntime
+        # 1.26) -> downstream pip check fails. Pin away from 0.6.3 (0.6.2 is clean).
+        - magika >=0.6.1,!=0.6.3,<0.7.0
+        - charset-normalizer
+        - defusedxml
+      # https://github.com/microsoft/markitdown/blob/main/packages/markitdown/pyproject.toml#L35
+      run_constraints:
+        - python-pptx
+        - mammoth >=1.11.0
+        - pandas
+        - openpyxl
+        - xlrd
+        - lxml
+        - pdfminer.six >=20251230
+        - pdfplumber >=0.11.9
+        - olefile
+        - pydub
+        - SpeechRecognition
+        - youtube-transcript-api >=1.0.0
+        - azure-ai-documentintelligence
+        - azure-identity
+    tests:
+      - python:
+          imports:
+            - markitdown
+          pip_check: true
+          python_version:
+            - ${{ python_min }}.*
+            - "*"
+      - requirements:
+          run:
+            - pip
+            - python ${{ python_min }}.*
+        script:
+          - markitdown --help
+
+  - package:
+      name: ${{ name|lower }}
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - ${{ pin_subpackage(name ~ '-core', exact=True) }}
+        - python-pptx
+        - mammoth >=1.11.0
+        - pandas
+        - openpyxl
+        - xlrd
+        - lxml
+        - pdfminer.six >=20251230
+        - pdfplumber >=0.11.9
+        - olefile
+        - youtube-transcript-api >=1.0.0
+        - azure-ai-documentintelligence
+        - azure-identity
+        # deliberately not pulled in, install them alongside markitdown if needed:
+        #  - pydub + SpeechRecognition ([audio-transcription]): speechrecognition is
+        #    capped at python <3.13 on conda-forge and pydub imports the stdlib
+        #    audioop module that 3.13 removed, so either would cap markitdown itself.
+        #  - azure-ai-contentunderstanding ([az-content-understanding]): upstream needs
+        #    >=1.2.0b1 for to_llm_input(), conda-forge only has 1.1.0.
+    tests:
+      - requirements:
+          run:
+            - python ${{ python_min }}.*
+        script:
+          # the converters import their backend lazily and only report the failure
+          # when asked to convert, so check the backends themselves. pdfminer.high_level
+          # in particular fails when pdfminer (dead) shadows pdfminer.six, see issue #17.
+          - python -c "import pdfminer.high_level, pdfplumber"
+          - python -c "import pptx, mammoth, lxml, pandas, openpyxl, xlrd, olefile, youtube_transcript_api"
+          - python -c "import azure.ai.documentintelligence, azure.identity"
+          - python -c "from markitdown import MarkItDown; MarkItDown()"
 
 about:
   summary: Utility tool for converting various files to Markdown
@@ -78,6 +124,9 @@ about:
   homepage: https://github.com/microsoft/markitdown
   description: |
     Python tool for converting files and office documents to Markdown.
+
+    markitdown installs the optional converter backends as well; use
+    markitdown-core for the mandatory dependencies only.
   repository: https://github.com/microsoft/markitdown
 
 extra:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -7,7 +7,7 @@ context:
   python_min: '3.10'
   python_max: '4.0'
 
-recipe:
+package:
   name: ${{ name|lower }}
   version: ${{ version }}
 
@@ -17,105 +17,77 @@ source:
 
 build:
   number: 1
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
+  python:
+    entry_points:
+      - markitdown = markitdown.__main__:main
 
-# markitdown-core carries the package with only the mandatory dependencies, so
-# every converter that needs an optional backend raises MissingDependencyException.
-# markitdown adds those backends on top, i.e. it is the equivalent of
-# `pip install markitdown[all]` and converts pdf/docx/xlsx/... out of the box.
-# https://github.com/conda-forge/markitdown-feedstock/issues/17
-outputs:
-  - package:
-      name: ${{ name|lower }}-core
-    build:
-      noarch: python
-      script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
-      python:
-        entry_points:
-          - markitdown = markitdown.__main__:main
-    requirements:
-      host:
-        - python ${{ python_min }}.*
-        - hatchling
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling
+    - pip
+  run:
+    - python >=${{ python_min }},<${{ python_max }}
+    - beautifulsoup4
+    - requests
+    - markdownify
+    # magika 0.6.3's wheel caps onnxruntime<=1.20.1 on win32 (a one-version aberration;
+    # absent in 0.6.1/0.6.2 and 1.0+), which conda can't satisfy on Windows (onnxruntime
+    # 1.26) -> downstream pip check fails. Pin away from 0.6.3 (0.6.2 is clean).
+    - magika >=0.6.1,!=0.6.3,<0.7.0
+    - charset-normalizer
+    - defusedxml
+    # Upstream's converters are all shipped, but each one imports its backend lazily
+    # and raises MissingDependencyException when it is absent, so the optional
+    # dependencies have to be installed for pdf/docx/xlsx/... to work at all. This is
+    # the [all] extra of
+    # https://github.com/microsoft/markitdown/blob/main/packages/markitdown/pyproject.toml#L35
+    # https://github.com/conda-forge/markitdown-feedstock/issues/17
+    - python-pptx
+    - mammoth >=1.11.0
+    - pandas
+    - openpyxl
+    - xlrd
+    - lxml
+    - pdfminer.six >=20251230
+    - pdfplumber >=0.11.9
+    - olefile
+    - youtube-transcript-api >=1.0.0
+    - azure-ai-documentintelligence
+    - azure-identity
+  run_constraints:
+    # The rest of the [all] extra, kept opt-in because installing it would restrict
+    # markitdown itself:
+    #  - pydub + SpeechRecognition ([audio-transcription]): conda-forge's
+    #    speechrecognition is capped at python <3.13 and pydub imports the stdlib
+    #    audioop module that 3.13 removed.
+    #  - azure-ai-contentunderstanding ([az-content-understanding]) is not constrained
+    #    at all: upstream needs >=1.2.0b1 for to_llm_input(), conda-forge only has 1.1.0.
+    - pydub
+    - SpeechRecognition
+
+tests:
+  - python:
+      imports:
+        - markitdown
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - requirements:
+      run:
         - pip
-      run:
-        - python >=${{ python_min }},<${{ python_max }}
-        - beautifulsoup4
-        - requests
-        - markdownify
-        # magika 0.6.3's wheel caps onnxruntime<=1.20.1 on win32 (a one-version aberration;
-        # absent in 0.6.1/0.6.2 and 1.0+), which conda can't satisfy on Windows (onnxruntime
-        # 1.26) -> downstream pip check fails. Pin away from 0.6.3 (0.6.2 is clean).
-        - magika >=0.6.1,!=0.6.3,<0.7.0
-        - charset-normalizer
-        - defusedxml
-      # https://github.com/microsoft/markitdown/blob/main/packages/markitdown/pyproject.toml#L35
-      run_constraints:
-        - python-pptx
-        - mammoth >=1.11.0
-        - pandas
-        - openpyxl
-        - xlrd
-        - lxml
-        - pdfminer.six >=20251230
-        - pdfplumber >=0.11.9
-        - olefile
-        - pydub
-        - SpeechRecognition
-        - youtube-transcript-api >=1.0.0
-        - azure-ai-documentintelligence
-        - azure-identity
-    tests:
-      - python:
-          imports:
-            - markitdown
-          pip_check: true
-          python_version:
-            - ${{ python_min }}.*
-            - "*"
-      - requirements:
-          run:
-            - pip
-            - python ${{ python_min }}.*
-        script:
-          - markitdown --help
-
-  - package:
-      name: ${{ name|lower }}
-    build:
-      noarch: generic
-    requirements:
-      run:
-        - ${{ pin_subpackage(name ~ '-core', exact=True) }}
-        - python-pptx
-        - mammoth >=1.11.0
-        - pandas
-        - openpyxl
-        - xlrd
-        - lxml
-        - pdfminer.six >=20251230
-        - pdfplumber >=0.11.9
-        - olefile
-        - youtube-transcript-api >=1.0.0
-        - azure-ai-documentintelligence
-        - azure-identity
-        # deliberately not pulled in, install them alongside markitdown if needed:
-        #  - pydub + SpeechRecognition ([audio-transcription]): speechrecognition is
-        #    capped at python <3.13 on conda-forge and pydub imports the stdlib
-        #    audioop module that 3.13 removed, so either would cap markitdown itself.
-        #  - azure-ai-contentunderstanding ([az-content-understanding]): upstream needs
-        #    >=1.2.0b1 for to_llm_input(), conda-forge only has 1.1.0.
-    tests:
-      - requirements:
-          run:
-            - python ${{ python_min }}.*
-        script:
-          # the converters import their backend lazily and only report the failure
-          # when asked to convert, so check the backends themselves. pdfminer.high_level
-          # in particular fails when pdfminer (dead) shadows pdfminer.six, see issue #17.
-          - python -c "import pdfminer.high_level, pdfplumber"
-          - python -c "import pptx, mammoth, lxml, pandas, openpyxl, xlrd, olefile, youtube_transcript_api"
-          - python -c "import azure.ai.documentintelligence, azure.identity"
-          - python -c "from markitdown import MarkItDown; MarkItDown()"
+        - python ${{ python_min }}.*
+    script:
+      - markitdown --help
+      # the converters swallow the backend ImportError until conversion time, so check
+      # the backends themselves. pdfminer.high_level in particular is what failed in
+      # issue #17, when pdfminer (dead) shadows pdfminer.six.
+      - python -c "import pdfminer.high_level, pdfplumber"
+      - python -c "import pptx, mammoth, lxml, pandas, openpyxl, xlrd, olefile, youtube_transcript_api"
+      - python -c "import azure.ai.documentintelligence, azure.identity"
 
 about:
   summary: Utility tool for converting various files to Markdown
@@ -124,9 +96,6 @@ about:
   homepage: https://github.com/microsoft/markitdown
   description: |
     Python tool for converting files and office documents to Markdown.
-
-    markitdown installs the optional converter backends as well; use
-    markitdown-core for the mandatory dependencies only.
   repository: https://github.com/microsoft/markitdown
 
 extra:


### PR DESCRIPTION
markitdown only shipped the mandatory dependencies, so every converter needing an optional backend failed with MissingDependencyException - `markitdown x.pdf` died on `import pdfminer.high_level` even though the recipe listed pdfminer.six under run_constraints (a constraint, not an install).

Split the recipe into two outputs:

- markitdown-core: the package with the mandatory dependencies only, i.e. the previous behaviour for anyone who wants the slim install
- markitdown: markitdown-core plus the optional backends, the equivalent of `pip install markitdown[all]`, so pdf/docx/xlsx/xls/pptx/outlook/youtube and azure document intelligence work with no extra steps

Two extras are deliberately left out of the metapackage and stay in run_constraints:

- pydub + SpeechRecognition ([audio-transcription]): conda-forge's speechrecognition is capped at python <3.13 and pydub imports the stdlib audioop module removed in 3.13, so either one would cap markitdown itself
- azure-ai-contentunderstanding ([az-content-understanding]): upstream needs
  >=1.2.0b1 for to_llm_input(), conda-forge only has 1.1.0

The markitdown test imports the backends directly, since the converters swallow the import error until conversion time.

Closes #17

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
